### PR TITLE
`Arm` vs `x86` readme

### DIFF
--- a/workaround_for_arm_numpy.md
+++ b/workaround_for_arm_numpy.md
@@ -1,0 +1,14 @@
+If there are issues with numpy and target architecture on MacOS ('arm' vs 'x86'), try the following:
+
+- close running terminal
+- go to Applications/utilities/ in finder, right-click on terminal and select show_info
+- select open with Rosetta
+- open new terminal window
+- uninstall numpy
+- reinstall numpy with flags '--compile (--no-cache-dir)'
+- - if you also have issues with open ssl certificate add flags '--trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org'
+- complete command: 'pip install --compile --no-cache-dir --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org numpy'
+- close terminal
+- go to Applications/utilities, right-click terminal and de-select open with Rosetta
+- open new terminal
+- run roobt_test...

--- a/workaround_for_arm_numpy.md
+++ b/workaround_for_arm_numpy.md
@@ -1,14 +1,14 @@
-If there are issues with numpy and target architecture on MacOS ('arm' vs 'x86'), try the following:
+If there are issues with numpy and target architecture on MacOS (`arm` vs `x86`), try the following:
 
 - close running terminal
-- go to Applications/utilities/ in finder, right-click on terminal and select show_info
-- select open with Rosetta
+- go to `Applications/utilities/` in finder, right-click on terminal and select `Get Info`
+- select `Open with Rosetta`
 - open new terminal window
 - uninstall numpy
-- reinstall numpy with flags '--compile (--no-cache-dir)'
-  - if you also have issues with open ssl certificate add flags '--trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org'
-  - complete command then: 'pip install --compile --no-cache-dir --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org numpy'
+- to reinstall numpy with flags `--compile --no-cache-dir` run `pip install --compile --no-cache-dir numpy`
+  - if you also have issues with open ssl certificate add flags `--trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org` to allow sources
+  - complete command then: `pip install --compile --no-cache-dir --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org numpy`
 - close terminal
-- go to Applications/utilities, right-click terminal and de-select open with Rosetta
+- go to `Applications/utilities`, right-click terminal, select `Get Info` and de-select `Open with Rosetta`
 - open new terminal
 - run roobt_test...

--- a/workaround_for_arm_numpy.md
+++ b/workaround_for_arm_numpy.md
@@ -6,8 +6,8 @@ If there are issues with numpy and target architecture on MacOS ('arm' vs 'x86')
 - open new terminal window
 - uninstall numpy
 - reinstall numpy with flags '--compile (--no-cache-dir)'
-- - if you also have issues with open ssl certificate add flags '--trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org'
-- complete command: 'pip install --compile --no-cache-dir --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org numpy'
+  - if you also have issues with open ssl certificate add flags '--trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org'
+  - complete command then: 'pip install --compile --no-cache-dir --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org numpy'
 - close terminal
 - go to Applications/utilities, right-click terminal and de-select open with Rosetta
 - open new terminal


### PR DESCRIPTION
how to handle webots install on arm architecture machines when lumpy throws error